### PR TITLE
i18n init

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="no">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
@@ -9,6 +9,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="/src/main.js"></script>
+    <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "testertailwind",
+  "name": "nablaweb-vue",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "testertailwind",
+      "name": "nablaweb-vue",
       "version": "0.0.0",
       "dependencies": {
         "@intlify/core-base": "^12.0.0-alpha.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,15 @@
       "name": "testertailwind",
       "version": "0.0.0",
       "dependencies": {
+        "@intlify/core-base": "^12.0.0-alpha.2",
+        "@intlify/unplugin-vue-i18n": "^6.0.8",
         "@supabase/supabase-js": "^2.49.4",
         "@types/markdown-it": "^14.1.2",
         "markdown-it": "^14.1.0",
         "postcss-import": "^16.1.0",
         "tsx": "^4.19.4",
         "vue": "^3.5.13",
+        "vue-i18n": "^11.1.5",
         "vue-router": "^4.4.5"
       },
       "devDependencies": {
@@ -516,6 +519,181 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
+      "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
+      "integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.28.0.tgz",
+      "integrity": "sha512-fnqSjGWd/CoIp4EXIxWVK/sHA6DOHN4+8Ix2cX5ycOY7LG0UY8nHCU5pIp2eaE1Mc7Qd8kHspYNzYXT2ojPLzg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
+      "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/core": "^0.14.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@faker-js/faker": {
       "version": "9.8.0",
       "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.8.0.tgz",
@@ -531,6 +709,323 @@
       "engines": {
         "node": ">=18.0.0",
         "npm": ">=9.0.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@intlify/bundle-utils": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@intlify/bundle-utils/-/bundle-utils-10.0.1.tgz",
+      "integrity": "sha512-WkaXfSevtpgtUR4t8K2M6lbR7g03mtOxFeh+vXp5KExvPqS12ppaRj1QxzwRuRI5VUto54A22BjKoBMLyHILWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/message-compiler": "^11.1.2",
+        "@intlify/shared": "^11.1.2",
+        "acorn": "^8.8.2",
+        "escodegen": "^2.1.0",
+        "estree-walker": "^2.0.2",
+        "jsonc-eslint-parser": "^2.3.0",
+        "mlly": "^1.2.0",
+        "source-map-js": "^1.0.1",
+        "yaml-eslint-parser": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependenciesMeta": {
+        "petite-vue-i18n": {
+          "optional": true
+        },
+        "vue-i18n": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@intlify/bundle-utils/node_modules/@intlify/message-compiler": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.1.5.tgz",
+      "integrity": "sha512-YLSBbjD7qUdShe3ZAat9Hnf9E8FRpN6qmNFD/x5Xg5JVXjsks0kJ90Zj6aAuyoppJQA/YJdWZ8/bB7k3dg2TjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "11.1.5",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/core-base": {
+      "version": "12.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-12.0.0-alpha.2.tgz",
+      "integrity": "sha512-sPWvQ1Z4Wyw9Kp8xqjAk2sMOeZ4pO7p/NL3Eol8l9a7iPyMTuHyJ2DZVbOBG6zDnCupvLAqnRMAT1LAgvx0QRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/message-compiler": "12.0.0-alpha.2",
+        "@intlify/shared": "12.0.0-alpha.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/core-base/node_modules/@intlify/shared": {
+      "version": "12.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-12.0.0-alpha.2.tgz",
+      "integrity": "sha512-P2DULVX9nz3y8zKNqLw9Es1aAgQ1JGC+kgpx5q7yLmrnAKkPR5MybQWoEhxanefNJgUY5ehsgo+GKif59SrncA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "12.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-12.0.0-alpha.2.tgz",
+      "integrity": "sha512-PD9C+oQbb7BF52hec0+vLnScaFkvnfX+R7zSbODYuRo/E2niAtGmHd0wPvEMsDhf9Z9b8f/qyDsVeZnD/ya9Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "12.0.0-alpha.2",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler/node_modules/@intlify/shared": {
+      "version": "12.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-12.0.0-alpha.2.tgz",
+      "integrity": "sha512-P2DULVX9nz3y8zKNqLw9Es1aAgQ1JGC+kgpx5q7yLmrnAKkPR5MybQWoEhxanefNJgUY5ehsgo+GKif59SrncA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.1.5.tgz",
+      "integrity": "sha512-+I4vRzHm38VjLr/CAciEPJhGYFzWWW4HMTm+6H3WqknXLh0ozNX9oC8ogMUwTSXYR/wGUb1/lTpNziiCH5MybQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/unplugin-vue-i18n": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@intlify/unplugin-vue-i18n/-/unplugin-vue-i18n-6.0.8.tgz",
+      "integrity": "sha512-Vvm3KhjE6TIBVUQAk37rBiaYy2M5OcWH0ZcI1XKEsOTeN1o0bErk+zeuXmcrcMc/73YggfI8RoxOUz9EB/69JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@intlify/bundle-utils": "^10.0.1",
+        "@intlify/shared": "^11.1.2",
+        "@intlify/vue-i18n-extensions": "^8.0.0",
+        "@rollup/pluginutils": "^5.1.0",
+        "@typescript-eslint/scope-manager": "^8.13.0",
+        "@typescript-eslint/typescript-estree": "^8.13.0",
+        "debug": "^4.3.3",
+        "fast-glob": "^3.2.12",
+        "js-yaml": "^4.1.0",
+        "json5": "^2.2.3",
+        "pathe": "^1.0.0",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2",
+        "unplugin": "^1.1.0",
+        "vue": "^3.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "petite-vue-i18n": "*",
+        "vue": "^3.2.25",
+        "vue-i18n": "*"
+      },
+      "peerDependenciesMeta": {
+        "petite-vue-i18n": {
+          "optional": true
+        },
+        "vue-i18n": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@intlify/vue-i18n-extensions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@intlify/vue-i18n-extensions/-/vue-i18n-extensions-8.0.0.tgz",
+      "integrity": "sha512-w0+70CvTmuqbskWfzeYhn0IXxllr6mU+IeM2MU0M+j9OW64jkrvqY+pYFWrUnIIC9bEdij3NICruicwd5EgUuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.24.6",
+        "@intlify/shared": "^10.0.0",
+        "@vue/compiler-dom": "^3.2.45",
+        "vue-i18n": "^10.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@intlify/shared": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@vue/compiler-dom": "^3.0.0",
+        "vue": "^3.0.0",
+        "vue-i18n": "^9.0.0 || ^10.0.0 || ^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@intlify/shared": {
+          "optional": true
+        },
+        "@vue/compiler-dom": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-i18n": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@intlify/vue-i18n-extensions/node_modules/@intlify/core-base": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-10.0.7.tgz",
+      "integrity": "sha512-mE71aUH5baH0me8duB4FY5qevUJizypHsYw3eCvmOx07QvmKppgOONx3dYINxuA89Z2qkAGb/K6Nrpi7aAMwew==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/message-compiler": "10.0.7",
+        "@intlify/shared": "10.0.7"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/vue-i18n-extensions/node_modules/@intlify/message-compiler": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-10.0.7.tgz",
+      "integrity": "sha512-nrC4cDL/UHZSUqd8sRbVz+DPukzZ8NnG5OK+EB/nlxsH35deyzyVkXP/QuR8mFZrISJ+4hCd6VtCQCcT+RO+5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "10.0.7",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/vue-i18n-extensions/node_modules/@intlify/shared": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-10.0.7.tgz",
+      "integrity": "sha512-oeoq0L5+5P4ShXa6jBQcx+BT+USe3MjX0xJexZO1y7rfDJdwZ9+QP3jO4tcS1nxhBYYdjvFTqe4bmnLijV0GxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/vue-i18n-extensions/node_modules/vue-i18n": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-10.0.7.tgz",
+      "integrity": "sha512-bKsk0PYwP9gdYF4nqSAT0kDpnLu1gZzlxFl885VH4mHVhEnqP16+/mAU05r1U6NIrc0fGDWP89tZ8GzeJZpe+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "10.0.7",
+        "@intlify/shared": "10.0.7",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -599,6 +1094,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
@@ -620,7 +1128,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -634,7 +1141,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -644,7 +1150,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -663,6 +1168,40 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
+      "integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1098,8 +1637,14 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
@@ -1145,6 +1690,130 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.34.0.tgz",
+      "integrity": "sha512-iEgDALRf970/B2YExmtPMPF54NenZUf4xpL3wsCRx/lgjz6ul/l13R81ozP/ZNuXfnLCS+oPmG7JIxfdNYKELw==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.34.0",
+        "@typescript-eslint/types": "^8.34.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.34.0.tgz",
+      "integrity": "sha512-9Ac0X8WiLykl0aj1oYQNcLZjHgBojT6cW68yAgZ19letYu+Hxd0rE0veI1XznSSst1X5lwnxhPbVdwjDRIomRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.34.0",
+        "@typescript-eslint/visitor-keys": "8.34.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.34.0.tgz",
+      "integrity": "sha512-+W9VYHKFIzA5cBeooqQxqNriAP0QeQ7xTiDuIOr71hzgffm3EL2hxwWBIIj4GuofIbKxGNarpKqIq6Q6YrShOA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.34.0.tgz",
+      "integrity": "sha512-9V24k/paICYPniajHfJ4cuAWETnt7Ssy+R0Rbcqo5sSFr3QEZ/8TSoUi9XeXVBGXCaLtwTOKSLGcInCAvyZeMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.34.0.tgz",
+      "integrity": "sha512-rOi4KZxI7E0+BMqG7emPSK1bB4RICCpF7QD3KCLXn9ZvWoESsOMlHyZPAHyG04ujVplPaHbmEvs34m+wjgtVtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.34.0",
+        "@typescript-eslint/tsconfig-utils": "8.34.0",
+        "@typescript-eslint/types": "8.34.0",
+        "@typescript-eslint/visitor-keys": "8.34.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.34.0.tgz",
+      "integrity": "sha512-qHV7pW7E85A0x6qyrFn+O+q1k1p3tQCsqIZ1KZ5ESLXY57aTvUd3/a4rdPTeXisvhXn2VQG0VSKUqs8KHF2zcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.34.0",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -1268,18 +1937,24 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-      "dev": true,
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/acorn-walk": {
@@ -1305,6 +1980,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-regex": {
@@ -1409,7 +2101,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bin-links": {
@@ -1446,7 +2137,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -1456,7 +2146,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -1498,6 +2187,25 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -1528,6 +2236,39 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -1591,7 +2332,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1604,7 +2344,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -1616,6 +2355,19 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "license": "MIT"
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1630,7 +2382,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1674,7 +2425,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1687,6 +2437,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -1797,17 +2554,272 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.28.0.tgz",
+      "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.20.0",
+        "@eslint/config-helpers": "^0.2.1",
+        "@eslint/core": "^0.14.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.28.0",
+        "@eslint/plugin-kit": "^0.3.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.3.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -1824,7 +2836,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -1833,11 +2844,24 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -1867,11 +2891,23 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -1879,6 +2915,44 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -1984,13 +3058,35 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/hasown": {
@@ -2019,11 +3115,37 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -2061,7 +3183,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2081,7 +3202,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -2094,7 +3214,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -2104,7 +3223,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jackspeak": {
@@ -2127,10 +3245,114 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonc-eslint-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.0.tgz",
+      "integrity": "sha512-WYDyuc/uFcGp6YtM2H0uKmUwieOuzeE/5YocFJLnLfclZ4inf3mRn8ZVy1s7Hxji7Jxm6Ss8gqpexD/GlKoGgg==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.5.0",
+        "eslint-visitor-keys": "^3.0.0",
+        "espree": "^9.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      }
+    },
+    "node_modules/jsonc-eslint-parser/node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lilconfig": {
@@ -2162,6 +3384,22 @@
         "uc.micro": "^2.0.0"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash.castarray": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
@@ -2180,7 +3418,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -2235,7 +3472,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -2245,7 +3481,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -2269,7 +3504,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -2320,11 +3554,28 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
+      "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "pathe": "^2.0.1",
+        "pkg-types": "^1.3.0",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -2356,6 +3607,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -2454,6 +3712,56 @@
         "node": ">= 6"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -2461,11 +3769,33 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2494,6 +3824,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2504,7 +3840,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -2531,6 +3866,23 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.5.3",
@@ -2693,6 +4045,16 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/proc-log": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
@@ -2701,6 +4063,16 @@
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/punycode.js": {
@@ -2716,7 +4088,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2785,6 +4156,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -2798,7 +4179,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -2809,7 +4189,7 @@
       "version": "4.38.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.38.0.tgz",
       "integrity": "sha512-5SsIRtJy9bf1ErAOiFMFzl64Ex9X5V7bnJ+WlFMb+zmP459OSWCEG7b0ERZ+PEU7xPt4OG3RHbrp1LJlXxYTrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.7"
@@ -2849,7 +4229,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2869,11 +4248,22 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -2886,7 +4276,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2905,6 +4294,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2912,6 +4311,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/string-width": {
@@ -3018,6 +4430,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
@@ -3059,6 +4484,19 @@
       },
       "engines": {
         "npm": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -3161,6 +4599,36 @@
         "node": ">=18"
       }
     },
+    "node_modules/terser": {
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.42.0.tgz",
+      "integrity": "sha512-UYCvU9YQW2f/Vwl+P0GfhxJxbUGLwd+5QrrGgLajzWAtC/23AX0vcise32kkP7Eu0Wu9VlzzHAXkLObgjQfFlQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.14.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -3233,7 +4701,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -3247,6 +4714,18 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
@@ -3329,12 +4808,24 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3350,11 +4841,30 @@
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "license": "MIT"
     },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "license": "MIT"
+    },
+    "node_modules/unplugin": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.16.1.tgz",
+      "integrity": "sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
@@ -3385,6 +4895,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -3527,6 +5047,58 @@
         }
       }
     },
+    "node_modules/vue-i18n": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.1.5.tgz",
+      "integrity": "sha512-XCwuaEA5AF97g1frvH/EI1zI9uo1XKTf2/OCFgts7NvUWRsjlgeHPrkJV+a3gpzai2pC4quZ4AnOHFO8QK9hsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "11.1.5",
+        "@intlify/shared": "11.1.5",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
+    "node_modules/vue-i18n/node_modules/@intlify/core-base": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.1.5.tgz",
+      "integrity": "sha512-xGRkISwV/2Trqb8yVQevlHm5roaQqy+75qwUzEQrviaQF0o4c5VDhjBW7WEGEoKFx09HSgq7NkvK/DAyuerTDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/message-compiler": "11.1.5",
+        "@intlify/shared": "11.1.5"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/vue-i18n/node_modules/@intlify/message-compiler": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.1.5.tgz",
+      "integrity": "sha512-YLSBbjD7qUdShe3ZAat9Hnf9E8FRpN6qmNFD/x5Xg5JVXjsks0kJ90Zj6aAuyoppJQA/YJdWZ8/bB7k3dg2TjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "11.1.5",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
     "node_modules/vue-router": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.0.tgz",
@@ -3558,6 +5130,12 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "license": "MIT"
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -3572,7 +5150,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -3582,6 +5159,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {
@@ -3731,13 +5318,28 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
       "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yaml-eslint-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-1.3.0.tgz",
+      "integrity": "sha512-E/+VitOorXSLiAqtTd7Yqax0/pAS3xaYMP+AUUJGOK1OZG3rhcj9fcJOM5HJ2VrP1FrStVCWr1muTfQCdj4tAA==",
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.0.0",
+        "yaml": "^2.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
       }
     },
     "node_modules/yn": {
@@ -3750,6 +5352,19 @@
       "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "testertailwind",
+  "name": "nablaweb-vue",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -11,12 +11,15 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@intlify/core-base": "^12.0.0-alpha.2",
+    "@intlify/unplugin-vue-i18n": "^6.0.8",
     "@supabase/supabase-js": "^2.49.4",
     "@types/markdown-it": "^14.1.2",
     "markdown-it": "^14.1.0",
     "postcss-import": "^16.1.0",
     "tsx": "^4.19.4",
     "vue": "^3.5.13",
+    "vue-i18n": "^11.1.5",
     "vue-router": "^4.4.5"
   },
   "devDependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,40 +1,38 @@
-<script setup>
-import './style.css'
-import './assets/fonts/fonts.css';
+<script setup lang="ts">
+    import { onMounted } from 'vue'
 
-import Header from './components/Header.vue';
-import MainContent from './components/MainContent.vue';
-import Footer from './components/Footer.vue';
+    import Header from '@/components/Header.vue';
+    import MainContent from '@/components/MainContent.vue';
+    import Footer from '@/components/Footer.vue';
+
+    import '@/style.css'
+    import '@/assets/fonts/fonts.css';
+    
+    // Set colour theme
+    function applyTheme(theme: string, mode: string) {
+        document.documentElement.setAttribute('data-theme', theme);
+        document.documentElement.setAttribute('data-mode', mode);   
+    }
+
+    function loadThemeFromLocalStorage() {
+        const savedTheme = localStorage.getItem('theme') || 'classic';
+        const savedMode = localStorage.getItem('mode') || 'light';
+        
+        applyTheme(savedTheme, savedMode);
+    }
+
+
+    onMounted(() => {
+        loadThemeFromLocalStorage()
+    })
 </script>
 
 <template>
-  <div class="min-h-screen flex flex-col">
-    <Header />
-    <main class="flex-1 bg-light">
-      <MainContent><RouterView /></MainContent>
-    </main>
-    <Footer />
-  </div>
+    <div class="min-h-screen flex flex-col">
+        <Header />
+        <main class="flex-1 bg-light">
+        <MainContent><RouterView /></MainContent>
+        </main>
+        <Footer />
+    </div>
 </template>
-
-<script>
-export default {
-  mounted() {
-    this.loadThemeFromLocalStorage(); // Apply the theme when the app loads
-  },
-  methods: {
-    applyTheme(theme, mode) {
-      document.documentElement.setAttribute('data-theme', theme);
-      document.documentElement.setAttribute('data-mode', mode);
-    },
-    loadThemeFromLocalStorage() {
-      // Load theme and mode from localStorage if available, or use defaults
-      const savedTheme = localStorage.getItem('theme') || 'classic'; // Default to 'classic'
-      const savedMode = localStorage.getItem('mode') || 'light'; // Default to 'light'
-
-      // Apply the theme and mode globally
-      this.applyTheme(savedTheme, savedMode);
-    },
-  },
-};
-</script>

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,15 +1,20 @@
+<script setup lang="ts">
+    import { useI18n } from 'vue-i18n'
+    const { t } = useI18n()
+</script>
+
 <template>
     <footer class="bg-primary text-gray-25 p-6">
         <div class="mx-auto flex w-240 justify-between items-start flex-wrap">
             <!-- Address Section -->
             <div class="m-3 font-lato text-m">
-                <h4 class="text-l mb-4">Adresse</h4>
+                <h4 class="text-l mb-4"> {{ t('adresse') }} </h4>
                 <p>Linjeforeningen Nabla<br>Kjemiblokk 2, Realfagsbygget<br>Sæm Sælands vei 10, NTNU<br>7034 Trondheim, Norway</p>
             </div>
 
             <!-- Social Media Section -->
             <div class="m-3 font-lato text-m">
-                <h4 class="text-l mb-4">Følg oss!</h4>
+                <h4 class="text-l mb-4"> {{ t('følg-oss') }}</h4>
                 <ul>
                     <li><a href="https://facebook.com" target="_blank">Facebook</a></li>
                     <li><a href="https://twitter.com" target="_blank">Twitter</a></li>
@@ -20,7 +25,7 @@
 
             <!-- Sponsor Logo Section -->
             <div class="m-3 font-lato text-m">
-                <h4 class="text-l mb-4">Sponset av</h4>
+                <h4 class="text-l mb-4"> {{ t('sponset-av') }} </h4>
                 <div class="flex items-center">
                     <a href="http://www.tekna.no/"><img class="mr-4 h-14" src="https://www.tekna.no/Static/Web2020/img/icons/tekna-logo-150-jubileum.png" alt="Tekna"></a>
                     <a class="ml-4 inline-block focus-visible:rounded-[3px] focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-1 focus-visible:outline-blueberry-600" href="http://www.sit.no/"><span class="sr-only"></span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 92 36.67" class="w-[90px]"><g transform="translate(-1445.384 -680.572)"><path fill="#FCFCFD" d="M1495.6,698.02c0.01,2.3,2.03,2.86,6.13,3.69c6.01,1.16,8.94,2.61,8.95,6.99   c0.02,5.05-3.57,8.49-9.24,8.51l-1.69,0.01c-5.56,0.02-9.17-3.4-9.17-5.64c0.04-0.18,0.16-0.33,0.34-0.39l3.25-1.64   c0.09-0.05,0.18-0.09,0.28-0.11c0.17,0,0.28,0.17,0.45,0.34c1.35,1.74,2.37,3.14,4.84,3.13l1.69-0.01   c2.58-0.01,4.26-1.47,4.26-3.27c-0.01-2.41-2.48-2.69-7.15-3.63c-5.34-1.05-7.87-2.67-7.89-6.88c-0.02-4.89,3.62-8.27,9.02-8.28   l1.69-0.01c5.56-0.02,9.17,3.4,9.17,5.64c0,0.17-0.11,0.28-0.34,0.39l-3.25,1.64c-0.11,0.05-0.22,0.09-0.34,0.11   c-0.17,0-0.22-0.17-0.39-0.34c-1.41-1.79-2.43-3.14-4.84-3.13l-1.69,0.01C1497.04,695.15,1495.58,696.23,1495.6,698.02"></path><path fill="#FCFCFD" d="M1516.9,686.83c-1.66,0.05-3.05-1.26-3.1-2.92c0-0.05,0-0.1,0-0.16   c-0.01-1.71,1.37-3.09,3.08-3.1c1.71-0.01,3.09,1.37,3.1,3.08C1519.98,685.44,1518.6,686.83,1516.9,686.83 M1518.96,716.59   l-3.93,0.01c-0.39,0-0.56-0.17-0.56-0.56l-0.08-24.15c0-0.39,0.17-0.56,0.56-0.56l3.93-0.01c0.39,0,0.56,0.17,0.56,0.56l0.08,24.15   C1519.52,716.42,1519.35,716.59,1518.96,716.59"></path><path fill="#FCFCFD" d="M1536.32,717.05c-5.11-0.12-9.17-4.35-9.07-9.46l-0.04-11.23c0-0.39-0.17-0.56-0.56-0.56   l-3.09,0.01c-0.39,0-0.56-0.17-0.56-0.56l0.11-1.97l6.44-6.87l0.39-0.17l1.74-0.01c0.39,0,0.56,0.17,0.56,0.56l0.01,3.93   c0,0.39,0.17,0.56,0.56,0.56l3.93-0.01c0.39,0,0.56,0.17,0.56,0.56l0.01,3.37c0,0.39-0.17,0.56-0.56,0.56l-3.93,0.01   c-0.39,0-0.56,0.17-0.56,0.56l0.04,11.23c0.01,1.2,0.46,2.35,1.25,3.25c0.51,0.62,1.69,1.01,3.38,1.73   c0.28,0.11,0.45,0.22,0.45,0.56l0.01,3.37C1537.38,716.98,1537.1,717.04,1536.32,717.05"></path><path fill="#FCFCFD" d="M1458.22,696.02c0,0-1.76-0.09-1.88-1.29s1.14-2.45,3.38-2.57c1.78-0.02,3.56-0.15,5.32-0.38   c0.99-0.35,1.61-1.34,1.49-2.39c-0.13-1.32-2.05-2.76-4.18-3.07c-1.51-0.22-7.54-1.71-13.37,8.18c-1.51,2.58-2.28,2.27-2.84,2.1   c-0.14-0.04-1.12-0.5-0.62-2.28c1.16-4.21,3.71-7.9,7.25-10.46c5.04-3.49,11.47-4.26,17.19-2.06c5.69,2.01,9.18,6.71,9.12,9.73   c-0.05,2.41-1.61,4.38-7.16,4.42C1466.19,696,1458.23,696.01,1458.22,696.02"></path><path fill="#FCFCFD" d="M1467.91,701.79c0,0,1.76,0.09,1.88,1.29s-1.14,2.46-3.38,2.57c-1.78,0.02-3.56,0.15-5.32,0.38   c-0.99,0.36-1.61,1.34-1.5,2.39c0.13,1.33,2.05,2.76,4.19,3.07c1.51,0.22,7.54,1.71,13.37-8.18c1.52-2.57,2.28-2.26,2.84-2.1   c0.15,0.05,1.13,0.5,0.63,2.28c-1.16,4.21-3.72,7.9-7.25,10.46c-5.04,3.49-11.47,4.26-17.19,2.06c-5.69-2.01-9.18-6.71-9.12-9.73   c0.05-2.42,1.61-4.38,7.16-4.42C1459.94,701.82,1467.9,701.8,1467.91,701.79"></path></g></svg></a>
@@ -30,11 +35,13 @@
     </footer>
 </template>
 
-<script setup>
-// No special logic in the footer
-</script>
-
-<style scoped>
-/* You can add any specific styles related to the footer component here */
-</style>
-  
+<i18n lang="yaml">
+    nb:
+        adresse: Adresse
+        følg-oss: Følg oss!
+        sponset-av: Sponset av
+    en: 
+        adresse: Address
+        følg-oss: Give us a follow!
+        sponset-av: "Proudly sponsored by:"
+</i18n>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,3 +1,170 @@
+<script setup lang="ts">
+  import {ref, onMounted} from 'vue'
+  import { useI18n } from 'vue-i18n'
+  const { t } = useI18n()
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const dropdownBox = document.getElementById('dropdown-box');
+    const headerItems = document.querySelectorAll('nav .group');
+    let isDropdownActive = false; // Track if dropdown is visible
+    let previousItem = null; // Track the previously hovered item
+    
+    const dropdownData = {
+      om: [
+        { to: "/om/nabla", text: "Om Oss", description: "Hva er Nabla?" },
+        { to: "/om/fond", text: "Nablas fond", description: "Fond?" },
+        { to: "/om/forretningsorden", text: "Om forretningsorden" },
+        { to: "/om/lover-og-forskrifter", text: "Nablas lover", description: "Våre lover og forskrifter" },
+        { to: "/om/retningslinjer", text: "Våre retningslinjer" },
+        { to: "/om/stillingsbeskrivelser", text: "Stillingsbeskrivelser", description: "Om styrestillinger" },
+        { to: "/om/tillitsvalgte", text: "Tillitsvalgte" }
+      ],
+      'for-komponenter': [
+        { to: "/for-komponenter/arrangementer", text: "Arrangementer" },
+        { to: "/for-komponenter/blogg", text: "Blogg" },
+        { to: "/for-komponenter/faglig-innhold", text: "Faglig innhold" },
+        { to: "/for-komponenter/interessegrupper", text: "Interessegrupper" },
+        { to: "/for-komponenter/kjellern", text: "Kjellern" },
+        { to: "/for-komponenter/komiteer", text: "Komiteer" },
+        { to: "/for-komponenter/kontakt", text: "Kontakt" },
+        { to: "/for-komponenter/motereferater", text: "Møtereferater" },
+        { to: "/for-komponenter/okonomisk-stotte", text: "Økonomisk støtte" },
+        { to: "/for-komponenter/stillingsannonser", text: "Stillingsannonser" },
+        { to: "/for-komponenter/styret", text: "Styret" },
+        { to: "/for-komponenter/tjenester", text: "Våre tjenester" },
+        { to: "/for-komponenter/utleggsskjema", text: "Utleggsskjema" },
+        { to: "/for-komponenter/varsling", text: "Varsling" }
+      ],
+      'for-bedrifter': [
+        { to: "/for-bedrifter/bedriftsbesok", text: "Bedriftsbesok" },
+        { to: "/for-bedrifter/bedriftspresentasjon", text: "Bedriftspresentasjon" },
+        { to: "/for-bedrifter/eureka", text: "Eureka" },
+        { to: "/for-bedrifter/kurs", text: "Kurs" },
+        { to: "/for-bedrifter/screeningintervju", text: "Screeningintervju" },
+        { to: "/for-bedrifter/stillingsannonse", text: "Stillingsannonse" }
+      ]
+    };
+
+    headerItems.forEach(item => {
+      const contentKey = item.dataset.dropdownContent;
+      dropdownBox.style.opacity = '0';
+      dropdownBox.style.visibility = 'hidden';
+
+      item.addEventListener('mouseenter', (e) => {
+        const boundingRect = item.getBoundingClientRect();
+        const links = dropdownData[contentKey] || [];
+        const grid = dropdownBox.querySelector('.grid');
+        grid.innerHTML = ''; // Clear any existing content
+
+        links.forEach(link => {
+          const routerLink = document.createElement('router-link'); // Create router-link element
+          routerLink.setAttribute('to', link.to); // Set the 'to' attribute
+          routerLink.className = 'p-2 transition ease-in-out duration-200 text-gray-darker font-semibold hover:text-primary-600 cursor-pointer'; // Add classes and pointer cursor
+
+          routerLink.textContent = link.text; // Set the link text
+          
+          // If there's a description, create a paragraph element
+          if (link.description) {
+            const description = document.createElement('p');
+            description.className = 'text-gray-dark font-normal';
+            description.textContent = link.description;
+            routerLink.appendChild(description); // Append the description to the link
+          }
+
+          grid.appendChild(routerLink); // Append the link to the grid
+        });
+
+        dropdownBox.style.display = 'none'; // Hide to measure width
+        dropdownBox.style.display = ''; // Show again to measure
+
+        const dropdownWidth = 560;
+
+        if (previousItem !== null) {
+          const previousRect = previousItem.getBoundingClientRect();
+          
+          dropdownBox.style.left = `${dropdownBox.offsetLeft + boundingRect.left + (boundingRect.width / 2) - previousRect.left - (previousRect.width / 2)}px`; // Update left position
+          dropdownBox.style.width = `${dropdownWidth}px`; // Update width
+          dropdownBox.style.transition = 'left 0.3s ease, width 0.3s ease'; // Add transition for smooth movement
+
+        } else {
+          dropdownBox.style.left = `${boundingRect.left + (boundingRect.width / 2) - (dropdownWidth / 2)}px`;
+          dropdownBox.style.width = `${dropdownWidth}px`;
+          dropdownBox.style.opacity = '1';
+          dropdownBox.style.visibility = 'visible';
+          dropdownBox.style.transition = 'opacity 0.5s ease, visibility 0.5s ease';
+        }
+
+        // Update the previous hovered item
+        previousItem = item;
+        isDropdownActive = true;
+      });
+
+      item.addEventListener('mouseleave', () => {
+        isDropdownActive = false;
+        checkDropdownVisibility();
+      });
+    });
+
+    dropdownBox.addEventListener('mouseenter', () => {
+      isDropdownActive = true; // Keep the dropdown active
+    });
+
+    dropdownBox.addEventListener('mouseleave', () => {
+      isDropdownActive = false; // Will check visibility
+      checkDropdownVisibility();
+    });
+
+    function checkDropdownVisibility() {
+      setTimeout(() => {
+        if (!isDropdownActive) {
+          dropdownBox.style.opacity = '0';
+          dropdownBox.style.visibility = 'hidden';
+          previousItem = null; // Reset previous item on hide
+        }
+      }, 300); // Delay to give smooth transition effect
+    }
+  });
+
+  const quotes = [
+    "Du kan nå endre fargetema i profilen din 🎨", 
+    "WebKom er best 💯", 
+    "Sjekk ut det nyeste Nabladet 🔆",
+    "Ny kodegolf! ⛳",
+    "Nye brettspill på kontoret 🎲",
+    "Oter 🦦",
+    "Lenge leve Snabla 🐘",
+    "Lenge leve Nabi 🐘",
+    "UFO? 🛸",
+    "KultKom ☄️",
+    "God påske! 🐣",
+    "Søk undergruppe 📅",
+    "Scary Nabla 🦇",
+    "🎃🎃🎃",
+    "Pumpkin spice latte 🍂",
+    "17.mai 🎉",
+    "Gratulerer med dagen 🎉",
+    "Søk UKAAAAA, bli slave du også 🧨",
+    "Skal DU stille på SKE? 😇",
+    "Du SKAL stille på SKE! 😈",
+    "God jul 🎄",
+    "Sjekket Joulekalenderen i dag? 🎁",
+    "Kanelbolleonsdag 🍴",
+    "Sconestorsdag 🫓",
+    "Fredagsquiz ❔",
+  ]
+
+  const currentQuote = ref('')
+
+  function generateQuote() {
+    const randomIndex = Math.floor(Math.random() * quotes.length);
+    currentQuote.value = quotes[randomIndex];
+  }
+
+  onMounted(() => {
+    generateQuote()
+  })
+</script>
+
 <template>
   <header class="sticky top-0 grid-rows-1 bg-primary text-gray-25 font-poppins text-title-6 h-header content-center">
     <div class="flex items-center justify-between pl-4 pr-6">
@@ -15,15 +182,15 @@
       <!-- Links in header -->
       <nav class="flex items-center">
         <div class="group" data-dropdown-content="om">
-          <router-link to="/om" class="content-center pr-4">Om Nabla</router-link>
+          <router-link to="/om" class="content-center pr-4"> {{ t('om-nabla' )}} </router-link>
         </div>
         <div class="group" data-dropdown-content="for-komponenter">
-          <router-link to="/for-komponenter" class="content-center px-4">For Komponenter</router-link>
+          <router-link to="/for-komponenter" class="content-center px-4"> {{ t('for-komponenter' )}} </router-link>
         </div>
         <div class="group" data-dropdown-content="for-bedrifter">
-          <router-link to="/for-bedrifter" class="content-center px-4">For Bedrifter</router-link>
+          <router-link to="/for-bedrifter" class="content-center px-4"> {{ t('for-bedrifter' )}} </router-link>
         </div>
-        <router-link to="/ny-student" class="content-center pl-4 pr-3">Ny student?</router-link>
+        <router-link to="/ny-student" class="content-center pl-4 pr-3"> {{ t('ny-student' )}} </router-link>
         <router-link to="/profil">
           <img class="h-8 w-8" src="../assets/images/profile.svg" alt="profil">
         </router-link>
@@ -37,174 +204,16 @@
   </header>
 </template>
 
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  const dropdownBox = document.getElementById('dropdown-box');
-  const headerItems = document.querySelectorAll('nav .group');
-  let isDropdownActive = false; // Track if dropdown is visible
-  let previousItem = null; // Track the previously hovered item
-  
-  const dropdownData = {
-    om: [
-      { to: "/om/nabla", text: "Om Oss", description: "Hva er Nabla?" },
-      { to: "/om/fond", text: "Nablas fond", description: "Fond?" },
-      { to: "/om/forretningsorden", text: "Om forretningsorden" },
-      { to: "/om/lover-og-forskrifter", text: "Nablas lover", description: "Våre lover og forskrifter" },
-      { to: "/om/retningslinjer", text: "Våre retningslinjer" },
-      { to: "/om/stillingsbeskrivelser", text: "Stillingsbeskrivelser", description: "Om styrestillinger" },
-      { to: "/om/tillitsvalgte", text: "Tillitsvalgte" }
-    ],
-    'for-komponenter': [
-      { to: "/for-komponenter/arrangementer", text: "Arrangementer" },
-      { to: "/for-komponenter/blogg", text: "Blogg" },
-      { to: "/for-komponenter/faglig-innhold", text: "Faglig innhold" },
-      { to: "/for-komponenter/interessegrupper", text: "Interessegrupper" },
-      { to: "/for-komponenter/kjellern", text: "Kjellern" },
-      { to: "/for-komponenter/komiteer", text: "Komiteer" },
-      { to: "/for-komponenter/kontakt", text: "Kontakt" },
-      { to: "/for-komponenter/motereferater", text: "Møtereferater" },
-      { to: "/for-komponenter/okonomisk-stotte", text: "Økonomisk støtte" },
-      { to: "/for-komponenter/stillingsannonser", text: "Stillingsannonser" },
-      { to: "/for-komponenter/styret", text: "Styret" },
-      { to: "/for-komponenter/tjenester", text: "Våre tjenester" },
-      { to: "/for-komponenter/utleggsskjema", text: "Utleggsskjema" },
-      { to: "/for-komponenter/varsling", text: "Varsling" }
-    ],
-    'for-bedrifter': [
-      { to: "/for-bedrifter/bedriftsbesok", text: "Bedriftsbesok" },
-      { to: "/for-bedrifter/bedriftspresentasjon", text: "Bedriftspresentasjon" },
-      { to: "/for-bedrifter/eureka", text: "Eureka" },
-      { to: "/for-bedrifter/kurs", text: "Kurs" },
-      { to: "/for-bedrifter/screeningintervju", text: "Screeningintervju" },
-      { to: "/for-bedrifter/stillingsannonse", text: "Stillingsannonse" }
-    ]
-  };
+<i18n lang="yaml">
+    nb:
+        om-nabla: Om Nabla
+        for-komponenter: For Komponenter
+        for-bedrifter: For Bedrifter
+        ny-student: Ny student?
+    en: 
+        om-nabla: About Nabla
+        for-komponenter: For Members
+        for-bedrifter: For Businesses
+        ny-student: New student?
 
-  headerItems.forEach(item => {
-    const contentKey = item.dataset.dropdownContent;
-    dropdownBox.style.opacity = '0';
-    dropdownBox.style.visibility = 'hidden';
-
-    item.addEventListener('mouseenter', (e) => {
-      const boundingRect = item.getBoundingClientRect();
-      const links = dropdownData[contentKey] || [];
-      const grid = dropdownBox.querySelector('.grid');
-      grid.innerHTML = ''; // Clear any existing content
-
-      links.forEach(link => {
-        const routerLink = document.createElement('router-link'); // Create router-link element
-        routerLink.setAttribute('to', link.to); // Set the 'to' attribute
-        routerLink.className = 'p-2 transition ease-in-out duration-200 text-gray-darker font-semibold hover:text-primary-600 cursor-pointer'; // Add classes and pointer cursor
-
-        routerLink.textContent = link.text; // Set the link text
-        
-        // If there's a description, create a paragraph element
-        if (link.description) {
-          const description = document.createElement('p');
-          description.className = 'text-gray-dark font-normal';
-          description.textContent = link.description;
-          routerLink.appendChild(description); // Append the description to the link
-        }
-
-        grid.appendChild(routerLink); // Append the link to the grid
-      });
-
-      dropdownBox.style.display = 'none'; // Hide to measure width
-      dropdownBox.style.display = ''; // Show again to measure
-
-      const dropdownWidth = 560;
-
-      if (previousItem !== null) {
-        const previousRect = previousItem.getBoundingClientRect();
-        
-        dropdownBox.style.left = `${dropdownBox.offsetLeft + boundingRect.left + (boundingRect.width / 2) - previousRect.left - (previousRect.width / 2)}px`; // Update left position
-        dropdownBox.style.width = `${dropdownWidth}px`; // Update width
-        dropdownBox.style.transition = 'left 0.3s ease, width 0.3s ease'; // Add transition for smooth movement
-
-      } else {
-        dropdownBox.style.left = `${boundingRect.left + (boundingRect.width / 2) - (dropdownWidth / 2)}px`;
-        dropdownBox.style.width = `${dropdownWidth}px`;
-        dropdownBox.style.opacity = '1';
-        dropdownBox.style.visibility = 'visible';
-        dropdownBox.style.transition = 'opacity 0.5s ease, visibility 0.5s ease';
-      }
-
-      // Update the previous hovered item
-      previousItem = item;
-      isDropdownActive = true;
-    });
-
-    item.addEventListener('mouseleave', () => {
-      isDropdownActive = false;
-      checkDropdownVisibility();
-    });
-  });
-
-  dropdownBox.addEventListener('mouseenter', () => {
-    isDropdownActive = true; // Keep the dropdown active
-  });
-
-  dropdownBox.addEventListener('mouseleave', () => {
-    isDropdownActive = false; // Will check visibility
-    checkDropdownVisibility();
-  });
-
-  function checkDropdownVisibility() {
-    setTimeout(() => {
-      if (!isDropdownActive) {
-        dropdownBox.style.opacity = '0';
-        dropdownBox.style.visibility = 'hidden';
-        previousItem = null; // Reset previous item on hide
-      }
-    }, 300); // Delay to give smooth transition effect
-  }
-});
-
-export default {
-  name: "Header",
-  data() {
-    return {
-      quotes: [
-        "Du kan nå endre fargetema i profilen din 🎨", 
-        "WebKom er best 💯", 
-        "Sjekk ut det nyeste Nabladet 🔆",
-        "Ny kodegolf! ⛳",
-        "Nye brettspill på kontoret 🎲",
-        "Oter 🦦",
-        "Lenge leve Snabla 🐘",
-        "Lenge leve Nabi 🐘",
-        "UFO? 🛸",
-        "KultKom ☄️",
-        "God påske! 🐣",
-        "Søk undergruppe 📅",
-        "Scary Nabla 🦇",
-        "🎃🎃🎃",
-        "Pumpkin spice latte 🍂",
-        "17.mai 🎉",
-        "Gratulerer med dagen 🎉",
-        "Søk UKAAAAA, bli slave du også 🧨",
-        "Skal DU stille på SKE? 😇",
-        "Du SKAL stille på SKE! 😈",
-        "God jul 🎄",
-        "Sjekket Joulekalenderen i dag? 🎁",
-        "Kanelbolleonsdag 🍴",
-        "Sconestorsdag 🫓",
-        "Fredagsquiz ❔",
-      ],
-      currentQuote: "Insert et tips" 
-    };
-  },
-  mounted() {
-    this.generateQuote();
-  },
-  methods: {
-    generateQuote() {
-      const randomIndex = Math.floor(Math.random() * this.quotes.length);
-      this.currentQuote = this.quotes[randomIndex];
-    }
-  }
-};
-</script>
-
-<style scoped>
-</style>
+</i18n>

--- a/src/components/MainContent.vue
+++ b/src/components/MainContent.vue
@@ -1,15 +1,10 @@
 <!-- We have a bug where the page loaded on a phone looks horrible, wider than the screen. Might be tailwind error here -->
+<script setup lang="ts">
+// No special logic
+</script>
 
 <template>
     <div class="text-dark font-poppins text-m max-w-280 mx-auto ">
         <slot></slot>
     </div>
 </template>
-
-<script setup>
-// No special logic
-</script>
-
-<style scoped>
-/* You can add any specific styles related to the component here */
-</style>

--- a/src/components/buttons/ThemeToggler.vue
+++ b/src/components/buttons/ThemeToggler.vue
@@ -1,24 +1,4 @@
-<template>
-  <div class="flex flex-col space-y-4 p-4 items-center">
-    <!-- Toggle Classic/Modern Button -->
-    <button
-      @click="toggleTheme"
-      class="px-4 py-2 rounded-lg text-white font-semibold transition-all duration-300 bg-primary"
-    >
-      {{ theme === 'classic' ? 'Switch to Modern' : 'Switch to Classic' }}
-    </button>
-
-    <!-- Toggle Lightmode/Darkmode Button -->
-    <button
-      @click="toggleMode"
-      class="px-4 py-2 rounded-lg text-white font-semibold transition-all duration-300 bg-secondary"
-    >
-      {{ mode === 'light' ? 'Switch to Darkmode' : 'Switch to Lightmode' }}
-    </button>
-  </div>
-</template>
-
-<script>
+<script lang="ts">
 export default {
   data() {
     return {
@@ -67,6 +47,22 @@ export default {
 };
 </script>
 
-<style scoped>
-/* Scoped styles if needed */
-</style>
+<template>
+  <div class="flex flex-col space-y-4 p-4 items-center">
+    <!-- Toggle Classic/Modern Button -->
+    <button
+      @click="toggleTheme"
+      class="px-4 py-2 rounded-lg text-white font-semibold transition-all duration-300 bg-primary"
+    >
+      {{ theme === 'classic' ? 'Switch to Modern' : 'Switch to Classic' }}
+    </button>
+
+    <!-- Toggle Lightmode/Darkmode Button -->
+    <button
+      @click="toggleMode"
+      class="px-4 py-2 rounded-lg text-white font-semibold transition-all duration-300 bg-secondary"
+    >
+      {{ mode === 'light' ? 'Switch to Darkmode' : 'Switch to Lightmode' }}
+    </button>
+  </div>
+</template>

--- a/src/components/general/login-card.vue
+++ b/src/components/general/login-card.vue
@@ -1,6 +1,6 @@
 <!-- Very temporary. Please make sure this doesn't end up in prod -->
 
-<script setup>
+<script setup lang='ts'>
     import { ref } from 'vue';
     import { supabase } from '@/lib/supabaseClient'
 

--- a/src/components/group-page/image-picker.vue
+++ b/src/components/group-page/image-picker.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
     import { ref, watch } from 'vue'
+    import { useI18n } from 'vue-i18n'
+    const { t } = useI18n()
+
     import InlineButton from '@/components/buttons/inline-button.vue';
 
     const props = defineProps<{
@@ -66,17 +69,17 @@
             class="m-auto items-center text-nowrap px-4 py-2 rounded-lg text-white font-semibold transition-all duration-300 bg-primary cursor-pointer"
             v-if="localImageURL === imageURL"
         >
-            Last opp
+            {{ t('last-opp') }}
         </label>
 
         <InlineButton
             v-if="localImageURL !== imageURL"
-            :text="'Avbryt'"
+            :text="t('avbryt')"
             @onClick="localImageURL = imageURL"
         />
 
         <InlineButton
-            :text="'Lagre endring'"
+            :text="t('lagre-endring')"
             :color="'bg-secondary'"
             @onClick="$emit('saveImage', localImageURL)"
             :disable-condition="localImageURL === imageURL"
@@ -86,7 +89,20 @@
         <img
         :src="localImageURL"
         class="w-full object-contain mt-4 rounded-xl"
-        alt="Flotte folk"
+        :alt="t('alt-text')"
         />
     </div>
 </template>
+
+<i18n lang="yaml">
+nb:
+    last-opp: Last opp
+    avbryt: Avbryt
+    lagre-endring: Lagre endring
+    alt-text: Bilde av gruppemedlemmene
+en: 
+    last-opp: Upload
+    avbryt: Cancel
+    lagre-endring: Save change
+    alt-text: Picture of the group members
+</i18n>

--- a/src/components/group-page/markdown-field.vue
+++ b/src/components/group-page/markdown-field.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
     import { ref, watch } from 'vue'
 
+    import { useI18n } from 'vue-i18n'
+    const { t } = useI18n()
+
     import markdownit from 'markdown-it'
     const md = markdownit()
 
@@ -23,17 +26,28 @@
 <template>
     <div class="flex flex-row gap-4">
         <div class="flex flex-col flex-1 gap-4">
-            <textarea class="w-full grow resize-none p-3 m-1 rounded-xl" v-model="localText" placeholder="NablaKom er hele nablas nabla-komite!"></textarea>
+            <textarea class="w-full grow resize-none p-3 m-1 rounded-xl" v-model="localText" :placeholder="t('placeholder')"></textarea>
         </div>
         <!-- Workaround for tailwind stripping all styling from normal html (smh) -->
         <article class="flex-1 reset-tailwind" v-html='md.render(localText)' v-if='text'></article>
     </div>
     <div class="flex flex-row gap-2 mb-4">
         <button class="mt-auto px-4 py-2 rounded-lg text-white font-semibold transition-all duration-300 bg-primary" @click="localText=text">
-            Gå tilbake
+            {{ t('gå-tilbake') }}
         </button>
         <button class="mt-auto px-4 py-2 rounded-lg text-white font-semibold transition-all duration-300 bg-secondary disabled:bg-gray" @click="$emit('saveText', localText)" :disabled="localText===text">
-            Lagre ny tekst
+            {{ t('lagre-ny-tekst') }}
         </button>
     </div>
 </template>
+
+<i18n lang="yaml">
+nb:
+    placeholder: NablaKom er hele nablas nabla-komite!
+    gå-tilbake: Gå tilbake
+    lagre-ny-tekst: Large ny tekst
+en:
+    placeholder: NablaKom is all of nabla's nabla-committee!
+    gå-tilbake: Cancel
+    lagre-ny-tekst: Save text
+</i18n>

--- a/src/components/group-page/markdown-field.vue
+++ b/src/components/group-page/markdown-field.vue
@@ -45,7 +45,7 @@
 nb:
     placeholder: NablaKom er hele nablas nabla-komite!
     gå-tilbake: Gå tilbake
-    lagre-ny-tekst: Large ny tekst
+    lagre-ny-tekst: Lagre ny tekst
 en:
     placeholder: NablaKom is all of nabla's nabla-committee!
     gå-tilbake: Cancel

--- a/src/components/group-page/member-admin-table.vue
+++ b/src/components/group-page/member-admin-table.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
     import { ref, watch, computed } from 'vue'
+    import { useI18n } from 'vue-i18n'
+    const { t } = useI18n()
+
     import { GroupMember, NablaUser } from '@/lib/types/frontend.types'
 
     const props = defineProps<{
@@ -92,11 +95,11 @@
     <table class="min-w-full table-auto mb-4">
         <thead>
             <tr>
-                <th class="w-auto whitespace-nowrap text-left px-2">Navn</th>
-                <th class="whitespace-nowrap px-2">Kull</th>
-                <th class="whitespace-nowrap">Rolle</th>
-                <th class="w-auto whitespace-nowrap px-2">Dato</th>
-                <th class="whitespace-nowrap px-2">Flytt</th>
+                <th class="w-auto whitespace-nowrap text-left px-2"> {{ t('navn') }} </th>
+                <th class="whitespace-nowrap px-2"> {{ t('kull') }} </th>
+                <th class="whitespace-nowrap"> {{ t('rolle') }} </th>
+                <th class="w-auto whitespace-nowrap px-2"> {{ t('dato') }} </th>
+                <th class="whitespace-nowrap px-2"> {{ t('flytt') }} </th>
                 <th class="whitespace-nowrap px-2"><!-- available action --></th>
             </tr>
         </thead>
@@ -110,12 +113,12 @@
                     {{ member.user.class ? member.user.class : '' }}
                 </td>
                 <td class="px-2">
-                    <textarea class="border rounded p-3 resize-none h-[2.5rem] min-w-3xs" placeholder="Kuleste medlem!" v-model="member.role"/>
+                    <textarea class="border rounded p-3 resize-none h-[2.5rem] min-w-3xs" :placeholder="t('rolle-placeholder')" v-model="member.role"/>
                 </td>
                 <td>
                     {{ member.date? new Date(member.date).toDateString(): '' }}
                 </td> 
-                <td>
+                <td class="justify-center">
                     <button class="mt-auto px-4 py-2 m-1 rounded-lg text-white font-semibold transition-all duration-300 bg-primary disabled:bg-gray" @click="incrementMember(index)" :disabled="index === 0">
                         Δ
                     </button>
@@ -125,12 +128,13 @@
                 </td>
                 <td>
                     <button class="mt-auto px-4 py-2 m-1 rounded-lg text-white font-semibold transition-all duration-300 bg-secondary disabled:bg-gray"
-                            v-if="member.role == props.members[index]?.role"
-                            @click="removeMember(index)":disabled="notRemovable.some(nonRemovableMember => nonRemovableMember.user.username == member.user.username)">
-                        Slett
+                        v-if="member.role == props.members[index]?.role"
+                        @click="removeMember(index)":disabled="notRemovable.some(nonRemovableMember => nonRemovableMember.user.username == member.user.username)"
+                    >
+                        {{ t('slett' )}}
                     </button>
                     <button class="mt-auto px-4 py-2 m-1 rounded-lg text-white font-semibold transition-all duration-300 bg-primary" v-else @click="$emit('saveMemberTable', localMemberTable)">
-                        Lagre
+                        {{ t('lagre')}}
                     </button>
                 </td>
             </tr>
@@ -139,7 +143,7 @@
                     <input
                         list="user-list"
                         v-model="searchString"
-                        placeholder="Søk etter ny medlem"
+                        :placeholder="t('søk-etter-ny-medlem')"
                         class="border rounded p-2 w-full"
                     />
                     <datalist id="user-list" >
@@ -154,11 +158,11 @@
                     </datalist>
                 </td>
                 <td class="px-2">
-                    <input v-model='newRole' placeholder="Den nye rollen" class="border rounded p-2 w-full"/>
+                    <input v-model='newRole' :placeholder="t('den-nye-rollen')" class="border rounded p-2 w-full"/>
                 </td>
                 <td colspan="3">
                     <button class="mt-auto px-4 py-2 rounded-lg text-white font-semibold transition-all duration-300 bg-primary disabled:bg-gray" @click="insertMember()" :disabled="!searchIsValid">
-                        Legg ny medlem inn! 
+                        {{ t('legg-ny-medlem-inn') }}
                     </button>
                 </td>
             </tr>
@@ -166,6 +170,35 @@
     </table>
     </div>
     <button class="mt-auto px-4 py-2 rounded-lg text-white font-semibold transition-all duration-300 bg-primary disabled:bg-gray" @click="sortMembersByDate()" :disabled="isSortedByDate">
-        Sorter etter dato
+        {{ t('sorter-etter-dato') }}
     </button>
 </template>
+
+<i18n lang='yaml'>
+nb:
+    navn: Navn
+    kull: Kull
+    rolle: Rolle
+    dato: Dato
+    flytt: Flytt
+    rolle-placeholder: Kuleste medlem!
+    slett: Slett
+    lagre: Lagre
+    søk-etter-ny-medlem: Søk etter ny medlem
+    den-nye-rollen: Den nye rollen
+    legg-ny-medlem-inn: Legg ny medlem inn!
+    sorter-etter-dato: Sorter etter dato
+en:
+    navn: Name
+    kull: Class
+    rolle: Role
+    dato: Date
+    flytt: Move
+    rolle-placeholder: Coolest member!
+    slett: Delete
+    lagre: Save
+    søk-etter-ny-medlem: Search for new member
+    den-nye-rollen: The member's role
+    legg-ny-medlem-inn: Add new member!
+    sorter-etter-dato: Sort by date
+</i18n>

--- a/src/components/group-page/user-picker.vue
+++ b/src/components/group-page/user-picker.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
     import { ref, watch } from 'vue'
     import { NablaUser, GroupMember } from '@/lib/types/frontend.types'
+    import { useI18n } from 'vue-i18n'
+    const { t } = useI18n()
     
     const props = defineProps<{
         current: GroupMember | undefined
@@ -19,7 +21,7 @@
         <input
             list="new-leader"
             v-model="chosenUsername"
-            placeholder="Nytt valg:"
+            :placeholder="t('nytt-valg')"
             class="border rounded p-2 w-full m-2"
         />
         <datalist id="new-leader" v-if="members" class="mx-4">
@@ -38,7 +40,16 @@
             @click="$emit('saveChosenUsername', chosenUsername)"
             :disabled="!members?.some(member => member.user.username === chosenUsername)"
             >
-                Velg
+                {{t('velg')}}
         </button>
     </div>
 </template>
+
+<i18n lang="yaml">
+nb:
+    nytt-valg: Nytt valg
+    velg: Velg
+en:
+    nytt-valg: New choice
+    velg: Choose
+</i18n>

--- a/src/components/home-components/Arrangementer.vue
+++ b/src/components/home-components/Arrangementer.vue
@@ -1,3 +1,7 @@
+<script setup lang='ts'>
+    // None as of yet
+</script>
+
 <template>
     <div class="flex justify-around mt-32">
         <!-- Arrangementer -->
@@ -14,18 +18,3 @@
         
     </div>
 </template>
-
-<script>
-export default {
-    name: "Arrangementer",
-};
-</script>
-
-<script setup>
-// No special logic
-</script>
-
-<style scoped>
-/* You can add any specific styles related to the component here */
-</style>
-  

--- a/src/components/home-components/NesteArrangement.vue
+++ b/src/components/home-components/NesteArrangement.vue
@@ -1,3 +1,7 @@
+<script setup lang='ts'>
+    // TODO
+</script>
+
 <template>
     <div class="flex items-center justify-between">
         
@@ -22,18 +26,3 @@
         
     </div>
 </template>
-
-<script>
-export default {
-    name: "NesteArrangement",
-};
-</script>
-
-<script setup>
-// No special logic
-</script>
-
-<style scoped>
-/* You can add any specific styles related to the component here */
-</style>
-  

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,0 @@
-import { createApp } from 'vue'
-import './style.css'
-import App from './App.vue'
-import router from './router'
-
-
-createApp(App).use(router).mount('#app')
-

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,23 @@
+import { createApp } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import './style.css'
+import App from './App.vue'
+import router from '@/router/'
+
+const app = createApp(App)
+
+const i18n = createI18n({
+    legacy: false,
+    locale: 'nb',
+    fallbackLocale: {
+        no: ['no', 'nb', 'nn', 'en'],
+        nb: ['nb', 'no', 'en'],
+        nn: ['nn', 'no', 'en'],
+        en: ['en', 'no']
+    },
+})
+
+app.use(router)
+app.use(i18n)
+app.mount('#app')

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -9,7 +9,7 @@ import GroupsPage from '@/views/for-studenter/undergrupper/nabla-groups.vue'
 import UnderKonstruksjonView from '@/views/diverse/error/under-konstruksjon.vue'
 import PageNotFoundView from '@/views/diverse/error/404.vue'
 
-import { groupPageGuard, groupAdminPageGuard } from './guards.js'
+import { groupPageGuard, groupAdminPageGuard } from './guards'
 
 const routes = [
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -9,7 +9,7 @@ import GroupsPage from '@/views/for-studenter/undergrupper/nabla-groups.vue'
 import UnderKonstruksjonView from '@/views/diverse/error/under-konstruksjon.vue'
 import PageNotFoundView from '@/views/diverse/error/404.vue'
 
-import { groupPageGuard, groupAdminPageGuard } from './guards.ts'
+import { groupPageGuard, groupAdminPageGuard } from './guards.js'
 
 const routes = [
 

--- a/src/views/diverse/error/404.vue
+++ b/src/views/diverse/error/404.vue
@@ -1,6 +1,6 @@
-<script setup>
-import '../../../style.css'
-import '../../../assets/fonts/fonts.css';
+<script setup lang="ts">
+import '@/style.css'
+import '@/assets/fonts/fonts.css';
 </script>
 
 <template>

--- a/src/views/diverse/error/under-konstruksjon.vue
+++ b/src/views/diverse/error/under-konstruksjon.vue
@@ -1,6 +1,5 @@
-<script setup>
-import '../../../style.css'
-import '../../../assets/fonts/fonts.css';
+<script setup lang="ts">
+import '@/style.css'
 </script>
 
 <template>

--- a/src/views/for-studenter/undergrupper/nabla-group-admin.vue
+++ b/src/views/for-studenter/undergrupper/nabla-group-admin.vue
@@ -1,17 +1,19 @@
 <script setup lang=ts>
-    import { ref, Ref } from 'vue';
-    import { useRoute } from 'vue-router';
+    import { ref, Ref } from 'vue'
+    import { useRoute } from 'vue-router'
+    import { useI18n } from 'vue-i18n'
+    const { t } = useI18n()
 
-    import { supabase } from '@/lib/supabaseClient';
-    import { useAuth } from '@/composables/useAuth';
+    import { supabase } from '@/lib/supabaseClient'
+    import { useAuth } from '@/composables/useAuth'
     import { useGroup } from '@/composables/useNablaGroup'
-    import { useGroupImageUpload } from '@/composables/useImageUpload';
+    import { useGroupImageUpload } from '@/composables/useImageUpload'
     
     import ImagePicker from '@/components/group-page/image-picker.vue'
     import MarkdownField from '@/components/group-page/markdown-field.vue'
     import MemberAdminTable from '@/components/group-page/member-admin-table.vue'
     import UserPicker from '@/components/group-page/user-picker.vue'
-    import { GroupMember, NablaUser } from '@/lib/types/frontend.types';
+    import { GroupMember, NablaUser } from '@/lib/types/frontend.types'
     
     const route = useRoute()
     const groupID = route.params.id as string
@@ -20,6 +22,7 @@
     const { group, loading, error, refreshGroupMembers} = useGroup(groupID)
     const { uploading, error: uploadError, publicURL, upload } = useGroupImageUpload(groupID)
 
+    // Functions below should probably be part of a composable, not this view.
     async function handleSaveImage(newImage: string) {
         try {
             const { error } = await supabase
@@ -121,29 +124,28 @@
         <!-- <img class = "object-fit: w-full object-cover" :src='nablaGroup.image' alt="Flotte folk"> -->
         <div class="mx-auto flex w-full px-4 sm:px-6 lg:px-8 max-w-[1200px] py-10">
             <div class="flex-1 pr-6">
-                
                 <div class="flex flex-row mb-4">
                     <h1 class="grow font-semibold tracking-tight text-title-2">
-                        Adminsida for {{ group.name }}    
+                        {{ t('adminsida-for') }} {{ group.name }}    
                     </h1>
-                    <RouterLink :to="`/for-komponenter/komiteer/${groupID}`" class="m-auto items-center text-nowrap px-4 py-2 rounded-lg text-white font-semibold transition-all duration-300 bg-primary text-center">
-                        Gå <br> tilbake
+                    <RouterLink :to="`/for-komponenter/komiteer/${groupID}`" class="m-auto items-center text-nowrap px-4 py-2 rounded-lg text-white font-semibold transition-all duration-300 bg-primary text-center" style="white-space: pre-line;">
+                        {{ t('gå-tilbake') }}
                     </RouterLink>
                 </div>
 
                 <h2 class="group flex items-center font-semibold tracking-tight text-subtitle-2 mb-4">
-                    Endre gruppebilde
+                    {{ t('endre-gruppebilde') }}
                 </h2>
-                Disse kan enten peke mot et bilde ute på nettet, eller lastes opp. Dersom dere laster opp - vi fastsetter maks ____ Mb per bilde. Det er ingen fast størrelse på bildet. Gjerne sjekk at det ser presentabelt på alle størrelser skjermer, fra mobiltelefon til storskjerm.
+                {{ t('endre-gruppebilde-tekst') }}
 
                 <ImagePicker :imageURL="group.groupPhoto? group.groupPhoto.href : ''" :uploadImage="upload" @saveImage="handleSaveImage"/>
                 
                 <br>
 
                 <h2 class="group flex items-center font-semibold tracking-tight text-subtitle-2 mb-4">
-                    Tekst om undergruppen:
+                    {{ t('tekst-om-gruppen')}}:
                 </h2>
-                Her er det nok best å være short & sweet, men dere har tilgang til markdown og HTML om noen har fryktelig lyst ;))
+                {{ t('tekst-om-gruppen-tekst')}}
                 
                 <br>
                 <br>
@@ -151,7 +153,7 @@
                 <MarkdownField :text="group.about ? group.about : ''" @saveText="handleSaveAboutText"/>
                 
                 <h2 class="group flex items-center font-semibold tracking-tight text-subtitle-2 mb-4">
-                    Medlemsliste:
+                    {{t('medlemsliste')}}:
                 </h2>
 
                 <MemberAdminTable
@@ -165,9 +167,9 @@
                 <br>
                 
                 <h2 class="group flex items-center font-semibold tracking-tight text-subtitle-2 mb-4">
-                    Endre gruppeleder:
+                    {{ t('endre-leder') }}:
                 </h2>
-                Faresone! Ikke reversibelt!
+                {{ t('faresone') }}
                 <br>
                 <UserPicker v-if="group"
                     :current="group.leader"
@@ -185,3 +187,36 @@
         </div>
     </div>
 </template>
+
+<i18n lang="yaml">
+nb:
+    adminsida-for: Adminsida for
+    gå-tilbake: "Gå \n tilbake"
+    endre-gruppebilde: Endre gruppebilde
+    endre-gruppebilde-tekst: >
+        Disse kan enten peke mot et bilde ute på nettet, eller lastes opp. Dersom dere laster opp - vi fastsetter
+        maks ____ Mb per bilde. Det er ingen fast størrelse på bildet. Gjerne sjekk at det ser presentabelt på alle
+        størrelser skjermer, fra mobiltelefon til storskjerm.
+    tekst-om-gruppen: Tekst om undergruppen
+    tekst-om-gruppen-tekst: >
+        Her er det nok best å være short & sweet, men dere har tilgang til markdown og HTML om noen har fryktelig
+        lyst ;))
+    medlemsliste: Medlemsliste
+    endre-leder: Endre gruppeleder
+    faresone: Fare! Ikke reversiblet!
+en:
+    adminsida-for: Admin page for
+    gå-tilbake: "Go \n back"
+    endre-gruppebilde: Change group photo
+    endre-gruppebilde-tekst: >
+        You can choose a web-link, or upload a picture to our servers. If you're uploading - we enforce a maxomum of
+        ____ Mb per image. There's no aspect ratio, however, so please make sure it looks alright on both large and
+        smaller screens.
+    tekst-om-gruppen: About text
+    tekst-om-gruppen-tekst: >
+        You'll likely be best off being short and sweet, however you have access to all of markdown and HTML if you
+        so wish ;))
+    medlemsliste: Member list
+    endre-leder: Change group leader
+    faresone: Danger zone! Non-reversible!
+</i18n>

--- a/src/views/for-studenter/undergrupper/nabla-group.vue
+++ b/src/views/for-studenter/undergrupper/nabla-group.vue
@@ -2,6 +2,8 @@
     import { useRoute, useRouter, RouterLink } from 'vue-router'
     import { computed, onMounted } from 'vue'
     import markdownit from 'markdown-it'
+    import { useI18n } from 'vue-i18n'
+    const { t } = useI18n()
 
     import { useGroup } from '@/composables/useNablaGroup'
     import { useAuth } from '@/composables/useAuth'
@@ -36,8 +38,8 @@
                     <h1 class="grow font-semibold tracking-tight text-title-2">
                         {{ group.name }}
                     </h1>
-                    <RouterLink :to="`/for-komponenter/komiteer/${groupID}/admin`" v-if="userIsAdmin" class="px-4 py-2 rounded-lg text-white font-semibold transition-all duration-300 bg-primary text-center">
-                        Hemmelige Saker <br> (Adminpanel)
+                    <RouterLink :to="`/for-komponenter/komiteer/${groupID}/admin`" v-if="userIsAdmin" class="px-4 py-2 rounded-lg text-white font-semibold transition-all duration-300 bg-primary text-center" style="white-space: pre-line;">
+                        {{ t('adminpanel') }}
                     </RouterLink>
                 </div>
                 <h2 class=" font-semibold tracking-tight text-subtitle-2 mb-4" v-if="group.mailList">
@@ -48,7 +50,7 @@
 
                 <div v-if="group.members">
                     <h2 class="group flex items-center font-semibold tracking-tight text-subtitle-2 mb-4">
-                        Medlemmer:
+                        {{ t('medlemmer') }}:
                     </h2>
                     <div class="flex flex-wrap justify-center gap-6">
                         <UserCard
@@ -66,3 +68,12 @@
         </div>
     </div>
 </template>
+
+<i18n lang="yaml">
+    nb:
+        adminpanel : "Hemmelige Saker \n (Adminpanel)"
+        medlemmer: Medlemmer
+    en:
+        adminpanel: "Secret Button \n (Admin page)"
+        medlemmer: Members
+</i18n>

--- a/src/views/for-studenter/undergrupper/nabla-groups.vue
+++ b/src/views/for-studenter/undergrupper/nabla-groups.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
     import { computed } from 'vue'
+    import { useI18n } from 'vue-i18n'
+    const { t } = useI18n()
+
     import { useGroups } from '@/composables/useNablaGroup'
     import GroupCard from '@/components/group-page/group-card.vue'
     import { GroupKind } from '@/lib/types/frontend.types'
@@ -16,7 +19,7 @@
 <template>
     <div class="flex w-full flex-grow flex-col" style="padding: 20pt">
         <h1>
-            Komiteer!
+            {{ t('komiteer') }}!
         </h1>
         <div class="flex flex-wrap justify-center gap-6">
             <GroupCard
@@ -28,7 +31,7 @@
             />
         </div>
         <h1>
-        Undergrupper!
+            {{ t('undergrupper') }}!
         </h1>
     </div>
         <div class="flex flex-wrap justify-center gap-6">
@@ -41,3 +44,12 @@
             />
         </div>
 </template>
+
+<i18n lang="yaml">
+    nb:
+        komiteer: Komiteer
+        undergrupper: Undergrupper
+    en:
+        komiteer: Committees
+        undergrupper: Interest Groups
+</i18n>

--- a/src/views/hjem/hjem.vue
+++ b/src/views/hjem/hjem.vue
@@ -1,9 +1,9 @@
-<script setup>
+<script setup lang='ts'>
 import '../../style.css'
 import '../../assets/fonts/fonts.css';
 
-import NesteArrangement from '../../components/home-components/NesteArrangement.vue';
-import Arrangementer from '../../components/home-components/Arrangementer.vue';
+import NesteArrangement from '@/components/home-components/NesteArrangement.vue';
+import Arrangementer from '@/components/home-components/Arrangementer.vue';
 
 </script>
 
@@ -11,9 +11,3 @@ import Arrangementer from '../../components/home-components/Arrangementer.vue';
     <NesteArrangement />
     <Arrangementer />
 </template>
-
-<script>
-export default {
-  name: 'HjemView',
-}
-</script>

--- a/src/views/ny-student/ny-student.vue
+++ b/src/views/ny-student/ny-student.vue
@@ -1,4 +1,4 @@
-<script setup>
+<script setup lang="ts">
 import '../../style.css'
 import '../../assets/fonts/fonts.css';
 

--- a/src/views/profil/profil.vue
+++ b/src/views/profil/profil.vue
@@ -1,6 +1,6 @@
-<script setup>
-  import '@/style.css'
-  import '@/assets/fonts/fonts.css';
+<script setup lang="ts">
+  import { useI18n } from 'vue-i18n';
+  const { locale } = useI18n()
   
   import { useAuth } from '@/composables/useAuth'
   import LoginCard from '@/components/general/login-card.vue';
@@ -17,13 +17,27 @@
   </div>
 
   <div style="margin: 40pt;" v-else-if="isAuthenticated">
-    <button class="px-4 py-2 rounded-lg text-white font-semibold transition-all duration-300 bg-primary" @click="signOut"> Sign Out </button>
+    <button
+      class="px-4 py-2 rounded-lg text-white font-semibold transition-all duration-300 bg-primary"
+      @click="signOut"
+    >
+      Sign Out
+    </button>
   </div>
   
   <div style="margin: 40pt;" v-else>
     <LoginCard/>
   </div>
 
+  <div class="flex justify-center">
+    <button
+    class="px-4 py-2 rounded-lg text-white font-semibold transition-all duration-300 bg-primary"
+    @click="locale == 'nb' ? locale = 'en' : locale = 'nb'"
+    >
+      Switch language
+    </button>
+  </div>
+  
   <div class="min-h-screen flex justify-center items-center">
     <ThemeToggler />
   </div>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,20 +1,27 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import vueI18n from '@intlify/unplugin-vue-i18n/vite'
+import path from 'path'
 import { fileURLToPath, URL } from 'node:url'
-
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
-  plugins: [vue()],
-  build: {
-    // Show uncompiled .vue and .ts to browser dev tools instead of just
-    sourcemap: mode === 'development',
-  },
+    plugins: [
+        vue(),
+        vueI18n({
+            module: 'petite-vue-i18n',  // Slightly smaller module than the entire i18n. Still like 5kb :((
+            // include: path.resolve(__dirname, 'src/**/*.{vue,js,ts}') //We can avoid importing i18n e
+        })
+    ],
+    build: {
+        // Show uncompiled .vue and .ts to browser dev tools instead of just y'know
+        sourcemap: mode === 'development',
+    },
 
-  // Fix prettier import root folder
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
+    // Fix prettier import root folder
+    resolve: {
+        alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url))
+        }
     }
-  }
 }))


### PR DESCRIPTION
Meant to solve #13 .

Installs and implements a vue library for `i18n`, an industry standard internationalization package, and shows how language is switched in the profile page.

It is possible it is overkill for us, however the way the package we use works is very ergonomic in Vue SFC's, where we simply get a translator object in the script, and define the translations we use in the file itself. This way we don't need to care about keeping an up-to-date translation file, it's in your face, and easy to use, which I hope will help with adoption.

Further it also allows for a seamless implementation of a nynorsk version of the page. All that's left is the changes to the database. An English name and about-text for groups and profiles, that is. The rest should hopefully be smoother sailing.