### PR TITLE
Nabla groups

### DIFF
--- a/src/composables/useNablaGroup.ts
+++ b/src/composables/useNablaGroup.ts
@@ -106,7 +106,7 @@ async function getGroupMembers(groupID: string): Promise<GroupMember[]> {
     return []
 }
 
-async function getActiveGroups(): Promise<NablaGroup[]> {
+async function getGroups(): Promise<NablaGroup[]> {
     try {
         const { data, error } = await supabase
             .schema("nablaweb_vue")
@@ -229,7 +229,7 @@ export function useGroups() {
 
     async function refreshGroups() {
         loading.value = true
-        const groupsResponse = await getActiveGroups()
+        const groupsResponse = await getGroups()
         if (groupsResponse) {
             groups.value = groupsResponse
         }

--- a/src/composables/useNablaGroup.ts
+++ b/src/composables/useNablaGroup.ts
@@ -62,7 +62,7 @@ async function getGroupMembers(groupID: string): Promise<GroupMember[]> {
             .schema("nablaweb_vue")
             .from("nabla_group_members")
             .select(
-                `    
+                `
                 memberRole: member_role,
                 dateJoined: date_joined,
                 isActive: is_active,
@@ -121,10 +121,11 @@ async function getActiveGroups(): Promise<NablaGroup[]> {
                 leader,
                 about,
                 groupPhoto: group_photo,
-                dateBegan: date_began
+                dateBegan: date_began,
+                isActive: is_active
                 `,
             )
-            .eq("is_active", true)
+
         if (error) {
             throw error
         }
@@ -143,6 +144,7 @@ async function getActiveGroups(): Promise<NablaGroup[]> {
                 about: group.about,
                 groupPhoto: makeURL(group.groupPhoto),
                 dateBegan: new Date(group.dateBegan),
+                isActive: group.isActive,
             }
         })
         return activeGroups

--- a/src/views/about/NablaGroups.vue
+++ b/src/views/about/NablaGroups.vue
@@ -10,22 +10,19 @@
     // useGroups also has an error and a loading that can be used in frontend
     const { groups } = useGroups()
     const committees = computed(() =>
-        groups.value.filter((group) => group.kind == GroupKind.Committee),
-    )
-    const interestGroups = computed(() =>
-        groups.value.filter((group) => group.kind == GroupKind.InterestGroup),
-    )
-
-    const inactiveGroups = computed(() =>
         groups.value.filter(
-            (group) => group.kind == GroupKind.InterestGroup && !group.isActive,
+            (group) => group.kind == GroupKind.Committee && group.isActive,
         ),
     )
 
-    const activeGroups = computed(() =>
+    const interestGroups = computed(() =>
         groups.value.filter(
             (group) => group.kind == GroupKind.InterestGroup && group.isActive,
         ),
+    )
+
+    const inactiveGroups = computed(() =>
+        groups.value.filter((group) => !group.isActive),
     )
 </script>
 
@@ -60,7 +57,7 @@
 
         <div class="flex flex-wrap justify-center gap-6">
             <GroupCard
-                v-for="group in activeGroups"
+                v-for="group in interestGroups"
                 :id="group.id"
                 :key="group.id"
                 :name="group.name"
@@ -72,24 +69,11 @@
             <summary class="mx-12 text-subtitle-4 font-semibold tracking-tight">
                 {{ t("inactive-groups") }}
             </summary>
+            <p class="mx-12">{{ t("inactive-groups-text") }}</p>
 
             <div class="flex flex-wrap justify-center gap-6">
                 <GroupCard
                     v-for="group in inactiveGroups"
-                    :id="group.id"
-                    :key="group.id"
-                    :name="group.name"
-                    :logo="group.logo"
-                />
-            </div>
-        </details>
-        <details closed>
-            <summary class="mx-12 text-subtitle-4 font-semibold tracking-tight">
-                {{ t("interesse-grupper") }}
-            </summary>
-            <div class="flex flex-wrap justify-center gap-6">
-                <GroupCard
-                    v-for="group in interestGroups"
                     :id="group.id"
                     :key="group.id"
                     :name="group.name"
@@ -103,12 +87,17 @@
 <i18n lang="yaml">
 nb:
     komiteer: Komiteer
-    interesse-grupper: Alle interessegrupper
-    inactive-groups: Inaktive interessegrupper
+    inactive-groups: Inaktive undergrupper
+    inactive-groups-text: Høres en av disse undergruppene ut som noe du vil starte opp igjen? Ta kontakt med styret da vel!
+    active-groups: Aktive interessegrupper
+nn:
+    komiteer: Komiteer
+    inactive-groups: Inaktive undergrupper
+    inactive-groups-text: Høyrest ei av desse undergruppene ut som noko du vil starte opp att? Ta kontakt med styret, då vel!
     active-groups: Aktive interessegrupper
 en:
     komiteer: Committees
-    interesse-grupper: All Interest Groups
-    inactive-groups: Inactive Interest Groups
+    inactive-groups: Inactive  Subgroups
+    inactive-groups-text: Does one of these subgroups sound like something you’d like to start up again? Get in touch with the board, then!
     active-groups: Active Interest Groups
 </i18n>

--- a/src/views/about/NablaGroups.vue
+++ b/src/views/about/NablaGroups.vue
@@ -15,6 +15,18 @@
     const interestGroups = computed(() =>
         groups.value.filter((group) => group.kind == GroupKind.InterestGroup),
     )
+
+    const inactiveGroups = computed(() =>
+        groups.value.filter(
+            (group) => group.kind == GroupKind.InterestGroup && !group.isActive,
+        ),
+    )
+
+    const activeGroups = computed(() =>
+        groups.value.filter(
+            (group) => group.kind == GroupKind.InterestGroup && group.isActive,
+        ),
+    )
 </script>
 
 <template>
@@ -41,26 +53,62 @@
                 :logo="group.logo"
             />
         </div>
-        <h1 class="text-subtitle-4 font-semibold tracking-tight">
-            {{ t("interesse-grupper") }}:
+
+        <h1 class="mx-12 text-subtitle-4 font-semibold tracking-tight">
+            {{ t("active-groups") }}
         </h1>
-    </div>
-    <div class="flex flex-wrap justify-center gap-6">
-        <GroupCard
-            v-for="group in interestGroups"
-            :id="group.id"
-            :key="group.id"
-            :name="group.name"
-            :logo="group.logo"
-        />
+
+        <div class="flex flex-wrap justify-center gap-6">
+            <GroupCard
+                v-for="group in activeGroups"
+                :id="group.id"
+                :key="group.id"
+                :name="group.name"
+                :logo="group.logo"
+            />
+        </div>
+
+        <details closed>
+            <summary class="mx-12 text-subtitle-4 font-semibold tracking-tight">
+                {{ t("inactive-groups") }}
+            </summary>
+
+            <div class="flex flex-wrap justify-center gap-6">
+                <GroupCard
+                    v-for="group in inactiveGroups"
+                    :id="group.id"
+                    :key="group.id"
+                    :name="group.name"
+                    :logo="group.logo"
+                />
+            </div>
+        </details>
+        <details closed>
+            <summary class="mx-12 text-subtitle-4 font-semibold tracking-tight">
+                {{ t("interesse-grupper") }}
+            </summary>
+            <div class="flex flex-wrap justify-center gap-6">
+                <GroupCard
+                    v-for="group in interestGroups"
+                    :id="group.id"
+                    :key="group.id"
+                    :name="group.name"
+                    :logo="group.logo"
+                />
+            </div>
+        </details>
     </div>
 </template>
 
 <i18n lang="yaml">
 nb:
     komiteer: Komiteer
-    interesse-grupper: Interessegrupper
+    interesse-grupper: Alle interessegrupper
+    inactive-groups: Inaktive interessegrupper
+    active-groups: Aktive interessegrupper
 en:
     komiteer: Committees
-    interesse-grupper: Interest Groups
+    interesse-grupper: All Interest Groups
+    inactive-groups: Inactive Interest Groups
+    active-groups: Active Interest Groups
 </i18n>


### PR DESCRIPTION
Add inactive interest groups to the NablaGroups page. getActiveGroups now returns all groups together with their active status, making it possible to filter by activity. Active groups are shown in a separate section, while inactive groups and all groups are shown in disclosure widgets.